### PR TITLE
Added writing of lat and lon origin to dot moos file.

### DIFF
--- a/missions/ros.moos.template
+++ b/missions/ros.moos.template
@@ -22,14 +22,10 @@ ProcessConfig = ANTLER
 {
   MSBetweenLaunches = 200
 
-  //Run = MOOSDB          @ NewConsole = true
-  //Run = pLogger         @ NewConsole = true
-  //Run = pHelmIvP        @ NewConsole = true
-
   Run = MOOSDB          @ NewConsole = false
   Run = pLogger         @ NewConsole = false
   Run = pHelmIvP        @ NewConsole = false
-  Run = pENC_Contact	@ NewConsole = true
+  //Run = pENC_Contact	@ NewConsole = true
   //Run = pENC_Print	@ NewConsole = false
 
   //Run = uSimMarine	    @ NewConsole = false

--- a/missions/ros.moos.template
+++ b/missions/ros.moos.template
@@ -13,6 +13,9 @@ TERM_REPORTING = true
 // Global log root directory
 GlobalLogPath = ./moos/
 
+// Lat and Long Origin
+LATLONORIGIN
+
 //------------------------------------------
 // Antler configuration  block
 ProcessConfig = ANTLER
@@ -26,6 +29,8 @@ ProcessConfig = ANTLER
   Run = MOOSDB          @ NewConsole = false
   Run = pLogger         @ NewConsole = false
   Run = pHelmIvP        @ NewConsole = false
+  Run = pENC_Contact	@ NewConsole = true
+  //Run = pENC_Print	@ NewConsole = false
 
   //Run = uSimMarine	    @ NewConsole = false
   //Run = pMarinePID      @ NewConsole = false
@@ -34,6 +39,11 @@ ProcessConfig = ANTLER
   //Run = pNodeReporter	  @ NewConsole = false
 }
 
+//------------------------------------------------
+#include plug_pENC_Contact.moos
+
+//------------------------------------------------
+#include plug_pENC_Print.moos
 
 //------------------------------------------
 // uProcessWatch config block

--- a/src/moos_ivp_bridge_node.cpp
+++ b/src/moos_ivp_bridge_node.cpp
@@ -113,6 +113,19 @@ bool OnMail(void *param)
 
 void startMOOS()
 {
+
+  bool hasOrigin = false;
+  while(!hasOrigin){
+    // This sleep is necessary, even in simulation when the "fix" is immediate.
+    ros::Duration(5).sleep();
+    ros::spinOnce();
+    if( (LatOrigin.compare("") != 0) && (LongOrigin.compare("") != 0)) {
+      hasOrigin = true;
+    }
+    ROS_INFO("Waiting for GPS Fix to set Lat/Long Origin...");
+  }
+  ROS_INFO("Have Lat/Lon Origin.");
+  
     std::string missionFileTemplate = ros::package::getPath("moos_ivp_bridge")+"/missions/ros.moos.template";
     std::string bhvFile = ros::package::getPath("moos_ivp_bridge")+"/missions/ros.bhv";
 
@@ -269,8 +282,6 @@ int main(int argc, char **argv)
     
     comms.Run("localhost",9000,"moos_ivp_bridge");
 
-    ros::Duration(5).sleep();
-    ros::spinOnce();
     startMOOS();
     ros::spin();    
 

--- a/src/moos_ivp_bridge_node.cpp
+++ b/src/moos_ivp_bridge_node.cpp
@@ -34,6 +34,8 @@ MutexProtectedBagWriter log_bag;
 MOOS::MOOSAsyncCommClient comms;
 
 bool initializedMOOS = false;
+std::string LatOrigin = "";
+std::string LongOrigin = "";
 
 bool OnConnect(void * param)
 {
@@ -117,17 +119,23 @@ void startMOOS()
     std::ifstream infile(missionFileTemplate);
     std::stringstream incontent;
     incontent << infile.rdbuf();
-    
-    std::regex br("BEHAVIORS");
-    
-    
-    std::string outcontent = std::regex_replace(incontent.str(),br,bhvFile);
 
+    std::cout << std::endl << std::endl;
+    std::cout << "LATORIGIN:" << LatOrigin << std::endl;
+    std::cout << "LONGORIGIN:" << LongOrigin << std::endl;
+
+    // Specify the default IvP Helm bhv file.
+    std::regex br("BEHAVIORS");
+    std::string outcontent = std::regex_replace(incontent.str(),br,bhvFile);
+    // Specify the LatOrigin and LonOrigin, captured from ROS topic /origin
+    std::regex br2("LATLONORIGIN");
+    std::string latlon = "LatOrigin=" + LatOrigin + "\n" + "LongOrigin=" + LongOrigin + "\n";
+    std::string outcontent2 = std::regex_replace(outcontent.c_str(),br2,latlon);
+
+    // Write .moos file.
     std::string missionFile = "ros.moos";
-    
     std::ofstream outfile(missionFile);
-    
-    outfile << outcontent;
+    outfile << outcontent2;
     
     boost::posix_time::ptime now = ros::WallTime::now().toBoost();
     std::string iso_now = std::regex_replace(boost::posix_time::to_iso_extended_string(now),std::regex(":"),"-");
@@ -219,6 +227,12 @@ void originCallback(const geographic_msgs::GeoPoint::ConstPtr& inmsg)
 {
     comms.Notify("LatOrigin", inmsg->latitude);
     comms.Notify("LongOrigin", inmsg->longitude);
+    std::stringstream ss;
+    ss << std::fixed << std::setprecision(8) << inmsg->latitude;    
+    LatOrigin = ss.str();
+    ss.str("");
+    ss << std::fixed << std::setprecision(8) << inmsg->longitude;
+    LongOrigin = ss.str();
 }
 
 int main(int argc, char **argv)
@@ -254,10 +268,12 @@ int main(int argc, char **argv)
     comms.SetOnConnectCallBack(OnConnect,&comms);
     
     comms.Run("localhost",9000,"moos_ivp_bridge");
-    
+
+    ros::Duration(5).sleep();
+    ros::spinOnce();
     startMOOS();
-    
-    ros::spin();
+    ros::spin();    
+
     
     log_bag.close();
     


### PR DESCRIPTION
This will writing the lat/lon origin to the ros.moos file for those moos apps that need it there. These include pmarineviewer and pENC_Contact. 

It could be improved by doing something smart if no GPS fix is available, and hence /origin has not been published yet. ros::spinOnce() is called to capture the /origin and there is currently no checking to see that the callback has been received. 

But this version currently works in the simulation environment where pseudo gps fixes are immediate.